### PR TITLE
修复make时报错

### DIFF
--- a/lib17mon/ipip.c
+++ b/lib17mon/ipip.c
@@ -73,7 +73,8 @@ int find(const char *ip, char *result) {
         memcpy(result, ipip.data + ipip.offset + index_offset - 262144, index_length);
         result[index_length] = '\0';
         int current_tabs = 0;
-        for (int i = 0; i < index_length; i++) {
+        int i;
+        for (i = 0; i < index_length; i++) {
             if (result[i] == '\t') {
                 if (current_tabs++ == 4) {
                     result[i] = 0;


### PR DESCRIPTION
修复make时报错
```
gcc -o bin/ipipnali nali.c lib17mon/ipip.c
lib17mon/ipip.c: In function ‘find’:
lib17mon/ipip.c:76:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
         for (int i = 0; i < index_length; i++) {
         ^
lib17mon/ipip.c:76:9: note: use option -std=c99 or -std=gnu99 to compile your code
make: *** [all] Error 1
```