### PR TITLE
fix: install to wrong directory when bindir / datadir not exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ all:nali.c lib17mon/ipip.c
 	gcc -o bin/ipipnali nali.c lib17mon/ipip.c
 	cp share/nali.sh bin/nali
 install:bin share
+	mkdir -p $(DESTDIR)$(bindir)
+	mkdir -p $(DESTDIR)$(datadir)
 	install bin/ipipnali $(DESTDIR)$(bindir)
 	install bin/nali $(DESTDIR)$(bindir)
 	install bin/nali-traceroute $(DESTDIR)$(bindir)

--- a/share/nali.sh
+++ b/share/nali.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
+DIR=$(dirname $0)
 if test $# -gt 0
 then
-    echo $@|perl /usr/local/share/nali.pl
+  echo $@|perl ${DIR}/../share/nali.pl
 else
-    perl /usr/local/share/nali.pl
+    perl ${DIR}/../share/nali.pl
 fi


### PR DESCRIPTION
All bin files will install to `$(DESTDIR)$(bindir)` if bindir / datadir not exist.
For example, I use `/Users/foo/local/nali` as my `prefix`.

Reproduce this by:

```
git clone git@github.com:dzxx36gyy/nali-ipip.git
cd nali-ipip
./configure --prefix=/tmp/nali && make && make install
ls /tmp/nali
```

Fix this issue by using `mkdir` to create these directories.